### PR TITLE
Fixed DoS due to XXE in xmlBundle

### DIFF
--- a/Model/XmlReader.php
+++ b/Model/XmlReader.php
@@ -31,16 +31,13 @@ class XmlReader
     public function processConvert($xmlString)
     {
         $result = [];
-        $entity_load = libxml_disable_entity_loader(true);
-        $errors = libxml_use_internal_errors(true);
+        libxml_disable_entity_loader(true);
 
         if(true === $this->isXml($xmlString))
         {
             $iterator = new SimpleXmlIterator($xmlString);
 
             $result = @$this->getArrayFromXml($iterator);
-            libxml_disable_entity_loader($entity_load);
-            libxml_use_internal_errors($errors);
         }
         return $result;
     }

--- a/Model/XmlReader.php
+++ b/Model/XmlReader.php
@@ -31,14 +31,17 @@ class XmlReader
     public function processConvert($xmlString)
     {
         $result = [];
+        $entity_load = libxml_disable_entity_loader(true);
+        $errors = libxml_use_internal_errors(true);
 
         if(true === $this->isXml($xmlString))
         {
             $iterator = new SimpleXmlIterator($xmlString);
 
-            $result = $this->getArrayFromXml($iterator);
+            $result = @$this->getArrayFromXml($iterator);
+            libxml_disable_entity_loader($entity_load);
+            libxml_use_internal_errors($errors);
         }
-
         return $result;
     }
 

--- a/Model/XmlReader.php
+++ b/Model/XmlReader.php
@@ -37,7 +37,7 @@ class XmlReader
         {
             $iterator = new SimpleXmlIterator($xmlString);
 
-            $result = @$this->getArrayFromXml($iterator);
+            $result = $this->getArrayFromXml($iterator);
         }
         return $result;
     }


### PR DESCRIPTION
### 📊 Metadata *
Denial of Service(DoS) due to XML Entity Injection. 

#### Bounty URL: https://www.huntr.dev/bounties/1-packagist-desperado%2Fxml-bundle/

### ⚙️ Description *
The ```xmlBundle``` package is vulnerable to XML External Entity (XXE) Injection which can result in denial of service attacks.

### 💻 Technical Description *
Fixed XXE Injection by adding ```libxml_disable_entity_loader```. 

### 🐛 Proof of Concept (PoC) *
```
<?php

include 'autoload.php';
use Desperado\XmlBundle\Model\XmlReader;

        $xmlString = '<?xml version="1.0" standalone="no" ?>
<!DOCTYPE request [
<!ENTITY a0 "dosdosdosdosdosdosdosdosdosdosdosdosdosdosdosdosdosdos">
<!ENTITY a1 "&a0;&a0;&a0;&a0;&a0;&a0;&a0;&a0;&a0;&a0;&a0;&a0;&a0;&a0;">
]>
<request>
                          <Details>
                              <PaymentParameters>
                                  <first_node>first_node_value</first_node>
                                  <second_node>&a1;</second_node>
                              </PaymentParameters>
                          </Details>
                      </request>';

        $xmlReader = new XmlReader;

	var_dump($xmlReader->processConvert($xmlString));
?>
```
Referance: https://github.com/pravednik/xmlBundle/issues/2

### 🔥 Proof of Fix (PoF) *
```
libxml_disable_entity_loader(true);
```

### 👍 User Acceptance Testing (UAT)
I am not sure on the fix. But with proper review we can fix this issue.
Fix Referance: https://github.com/openid/php-openid/commit/625c16bb28bb120d262b3f19f89c2c06cb9b0da9